### PR TITLE
Add encoder sensors to info.json

### DIFF
--- a/config/info.json
+++ b/config/info.json
@@ -1,5 +1,19 @@
 {
   "keyboard_name": "corne_xiao_v1",
+  "encoder": {
+    "rotary": [
+      {
+        "pin_a": "D5",
+        "pin_b": "D4",
+        "resolution": 4
+      },
+      {
+        "pin_a": "D4",
+        "pin_b": "D5",
+        "resolution": 4
+      }
+    ]
+  },
   "layouts": {
     "LAYOUT": {
       "layout": [


### PR DESCRIPTION
## Summary
- add two rotary encoder definitions for the left and right sensors in `info.json`

## Testing
- `jq empty config/info.json`

------
https://chatgpt.com/codex/tasks/task_e_6840185d5cf4832cbcb288d6627cd2eb